### PR TITLE
Tweaks to list codes table

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -195,7 +195,7 @@ impl InviteCodeManager {
             .striped(true)
             .resizable(true)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
-            .columns(Column::auto().resizable(true), 6)
+            .columns(Column::auto().resizable(true), 7)
             .min_scrolled_height(0.0)
             .max_scroll_height(available_height);
         table

--- a/src/app.rs
+++ b/src/app.rs
@@ -204,6 +204,9 @@ impl InviteCodeManager {
                     ui.heading("Code");
                 });
                 header.col(|ui| {
+                    ui.heading("Created At");
+                });
+                header.col(|ui| {
                     ui.heading("Used");
                 });
                 header.col(|ui| {
@@ -225,7 +228,10 @@ impl InviteCodeManager {
                         row.col(|ui| {
                             ui.label(code.code.as_str());
                         });
-                        row.col(|ui| match code.available > 0 {
+                        row.col(|ui| {
+                            ui.label(code.created_at.as_str());
+                        });
+                        row.col(|ui| match code.available < 1 || code.uses.len() > 0 {
                             true => {
                                 ui.label("y");
                             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -231,7 +231,7 @@ impl InviteCodeManager {
                         row.col(|ui| {
                             ui.label(code.created_at.as_str());
                         });
-                        row.col(|ui| match code.available < 1 || code.uses.len() > 0 {
+                        row.col(|ui| match code.available < 1 || !code.uses.is_empty() {
                             true => {
                                 ui.label("y");
                             }


### PR DESCRIPTION
## Description

This PR adds two changes to the List Codes page:

1. Add a column to show when the codes were created
2. Fix the "Used?" column:
  - It's currently checking for `code.available > 1 then 'y' else 'n'` meaning it will be shown as _used_ if `available > 1`
  - Also I've noticed that `available` is consistently `1` even if a code is used, so I've added a second check ƒor the `uses` array

## Testing

Validated by running locally and confirming both the new column shown and the correct behavior for the `Used?` column

<img width="954" height="251" alt="Screenshot 2025-10-18 at 12 26 46 AM" src="https://github.com/user-attachments/assets/27d91803-5558-462f-ac06-390c13b7afc8" />


## Type of Change

<!-- Mark relevant options with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements