### PR TITLE
Record username in 2FA token

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1261,7 +1261,9 @@ mod tests {
             6,
             1,
             30,
-            Secret::Raw(test_secret.as_bytes().to_vec()).to_bytes().unwrap(),
+            Secret::Raw(test_secret.as_bytes().to_vec())
+                .to_bytes()
+                .unwrap(),
             Some("Northsky".to_string()),
             test_username.to_string(),
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -872,7 +872,7 @@ impl InviteCodeManager {
                 30,
                 Secret::Encoded(res.0).to_bytes().unwrap(),
                 Some("Northsky".to_string()),
-                "Northsky".to_string(),
+                self.username.clone(),
             )
             .unwrap();
             let qr_code = totp.get_qr_png().unwrap();
@@ -1245,4 +1245,29 @@ struct GenerateOtpResponse {
 struct LoginRequest {
     pub username: String,
     pub password: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_totp_uses_username_as_account_name() {
+        let test_username = "testuser@example.com";
+        let test_secret = "JBSWY3DPEHPK3PXP";
+
+        let totp = TOTP::new(
+            Algorithm::SHA1,
+            6,
+            1,
+            30,
+            Secret::Raw(test_secret.as_bytes().to_vec()).to_bytes().unwrap(),
+            Some("Northsky".to_string()),
+            test_username.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(totp.account_name, test_username);
+        assert_eq!(totp.issuer, Some("Northsky".to_string()));
+    }
 }


### PR DESCRIPTION
## Description

When creating a 2FA token for the app, both the issuer and the account name are recorded as "Northsky". When setting up 2FA for multiple users, you'd have multiple tokens on your authenticator app with no way of differentiating them.

This change sets the username field, so a new 2FA token will show up with the proper name on an authentication app.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

Unit test added to cover the change.

## Type of Change

<!-- Mark relevant options with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements